### PR TITLE
Fixes/9

### DIFF
--- a/Sources/Satin/Pipelines/Chunks/PixelInfoInitNormal.metal
+++ b/Sources/Satin/Pipelines/Chunks/PixelInfoInitNormal.metal
@@ -20,5 +20,18 @@ pixel.normal = normalize(TBN * mapNormal);
 #endif
 
 #else
-pixel.normal = normalize(in.normal);
+
+const float3 Q1 = dfdx(in.worldPosition);
+const float3 Q2 = dfdy(in.worldPosition);
+const float2 st1 = dfdx(in.texcoord);
+const float2 st2 = dfdy(in.texcoord);
+
+float3 normal = in.normal;
+float3 tangent = normalize(Q1 * st2.y - Q2 * st1.y);
+float3 bitangent = -normalize(cross(normal, tangent));
+
+pixel.normal = normalize(normal);
+pixel.tangent = tangent;
+pixel.bitangent = bitangent;
+
 #endif

--- a/Sources/Satin/Pipelines/Chunks/PixelInfoInitNormal.metal
+++ b/Sources/Satin/Pipelines/Chunks/PixelInfoInitNormal.metal
@@ -17,6 +17,8 @@ float3 bitangent = -normalize(cross(normal, tangent));
 const float3x3 TBN = float3x3(tangent, bitangent, normal);
 
 pixel.normal = normalize(TBN * mapNormal);
+pixel.tangent = tangent;
+pixel.bitangent = bitangent;
 #endif
 
 #else
@@ -33,5 +35,4 @@ float3 bitangent = -normalize(cross(normal, tangent));
 pixel.normal = normalize(normal);
 pixel.tangent = tangent;
 pixel.bitangent = bitangent;
-
 #endif


### PR DESCRIPTION
This PR fixes uninitialized pixel struct values for certain cases (no tangent, bitangent, or no texture coord), resolving enhanced PBR rendering / material glitches when anisotropy is non zero. 