### PR TITLE
Fix visionOS Build

### DIFF
--- a/Example/Example/Renderers/Vision/ImmersiveSuperShapesRenderer.swift
+++ b/Example/Example/Renderers/Vision/ImmersiveSuperShapesRenderer.swift
@@ -100,9 +100,9 @@ final class ImmersiveSuperShapesRenderer: ImmersiveBaseRenderer {
         mesh.scale = .init(repeating: 0.25)
         mesh.cullMode = .none
 
-        parametersSubscription = parameters.objectWillChange.sink { [weak self] in
-            self?.updateGeometry()
-        }
+        // parametersSubscription = parameters.objectWillChange.sink { [weak self] in
+        //     self?.updateGeometry()
+        // }
     }
 
     override func update() {


### PR DESCRIPTION
Fixes build error on visionOS by doing the same thing as [here](https://github.com/Fabric-Project/Satin/blob/599759f02d8a108e996a853a2af5b6f9ee98db99/Example/Example/Renderers/Geometry/SuperShapesRenderer.swift#L199C1-L201C12) by commenting out parameters.objectWillChange.sink in the setup. 

Should the commented code be removed entirely? Not familiar enough with Satin yet to know. 

Before: Build failed
`Satin/Example/Example/Renderers/Vision/ImmersiveSuperShapesRenderer.swift:103:45: error: value of type 'ParameterGroup' has no member 'objectWillChange'
        parametersSubscription = parameters.objectWillChange.sink { [weak self] in
                                 ~~~~~~~~~~ ^~~~~~~~~~~~~~`

After: Build succeeds and demo works on visionOS