### PR TITLE
fix unsynchronized cache reads in ShaderPipelineCache and ComputeShaderPipelineCache

### DIFF
--- a/Sources/Satin/Compute/Utilities/ComputeShaderPipelineCache.swift
+++ b/Sources/Satin/Compute/Utilities/ComputeShaderPipelineCache.swift
@@ -131,7 +131,7 @@ public final class ComputeShaderPipelineCache: Sendable {
 
             return parameters
         }
-        else if let reflection = updatePipelineReflectionCache[configuration] {
+        else if let reflection = getUpdatePipelineReflection(configuration: configuration) {
             for binding in reflection.bindings {
                 if binding.index == ComputeBufferIndex.Uniforms.rawValue,
                    let bufferBinding = binding as? MTLBufferBinding,
@@ -176,7 +176,7 @@ public final class ComputeShaderPipelineCache: Sendable {
 
             return [buffer]
         }
-        else if let reflection = updatePipelineReflectionCache[configuration] {
+        else if let reflection = getUpdatePipelineReflection(configuration: configuration) {
             var parameters = [ParameterGroup]()
 
             for binding in reflection.bindings {

--- a/Sources/Satin/Shaders/Utilities/ShaderPipelineCache.swift
+++ b/Sources/Satin/Shaders/Utilities/ShaderPipelineCache.swift
@@ -125,7 +125,7 @@ public final class ShaderPipelineCache: Sendable {
     public static func getShadowPipeline(configuration: ShaderConfiguration) throws -> MTLRenderPipelineState? {
         var cachedShadowPipeline: MTLRenderPipelineState?
 
-        pipelineCacheQueue.sync {
+        shadowPipelineCacheQueue.sync {
             cachedShadowPipeline = shadowPipelineCache[configuration]
         }
 
@@ -176,7 +176,13 @@ public final class ShaderPipelineCache: Sendable {
     }
 
     public static func getPipelineParameters(configuration: ShaderConfiguration) throws -> ParameterGroup? {
-        if let parameters = pipelineParametersCache[configuration] { return parameters }
+        var cachedParameters: ParameterGroup?
+
+        pipelineParametersCacheQueue.sync {
+            cachedParameters = pipelineParametersCache[configuration]
+        }
+
+        if let cachedParameters { return cachedParameters }
 
         if let pipelineURL = configuration.pipelineURL,
            let shaderSource = try ShaderSourceCache.getSource(url: pipelineURL),
@@ -190,7 +196,7 @@ public final class ShaderPipelineCache: Sendable {
 
             return parameters
         }
-        else if let reflection = pipelineReflectionCache[configuration] {
+        else if let reflection = getPipelineReflection(configuration: configuration) {
             for binding in reflection.fragmentBindings {
                 if binding.index == FragmentBufferIndex.MaterialUniforms.rawValue,
                    let bufferBinding = binding as? MTLBufferBinding,


### PR DESCRIPTION
Each static cache dictionary is guarded by its own concurrent queue: reads via queue.sync, writes via queue.sync(flags: .barrier). Five accesses broke the pattern. ShaderPipelineCache.getPipelineParameters read pipelineParametersCache and pipelineReflectionCache with no queue at all, and getShadowPipeline read shadowPipelineCache under pipelineCacheQueue — the wrong queue, so the read had no mutual exclusion against shadowPipelineCacheQueue's barrier writes. ComputeShaderPipelineCache.getPipelineParameters and getPipelineBuffers read updatePipelineReflectionCache with no queue. An unsynchronized dictionary read racing a barrier write is undefined behavior — the dictionary can reallocate mid-read, and a downstream test suite historically segfaulted inside ShaderPipelineCache.getPipelineParameters when multiple renderers compiled shaders concurrently.

Reads now use their own queues, via the existing synchronized getters where one exists (getPipelineReflection, getUpdatePipelineReflection). Cache hit/miss semantics are unchanged. The sibling caches (ShaderLibraryCache, ShaderSourceCache, ShaderLibrarySourceCache) were audited and already follow the pattern correctly.

Via Claude Fable 5