### PR TITLE
MetalView: stop the render loop when leaving a window

### DIFF
--- a/Sources/Satin/Views/MetalView.swift
+++ b/Sources/Satin/Views/MetalView.swift
@@ -124,8 +124,11 @@ public final class MetalView: NSView, CALayerDelegate, CAMetalDisplayLinkDelegat
         else {
 #if DEBUG_VIEW
             print("viewDidMoveToWindow - MetalView: \(delegate?.id) - NO WINDOW")
-            stopRenderLoop()
 #endif
+            // Leaving a window invalidates the display link and its
+            // willClose observer, so re-hosting in another window rebuilds
+            // both against that window in setupRenderLoop.
+            stopRenderLoop()
         }
     }
 


### PR DESCRIPTION
The no-window branch of viewDidMoveToWindow only called stopRenderLoop() inside #if DEBUG_VIEW, so a view removed from its window kept its display link alive and never invalidated it. Stopping on exit makes re-hosting a supported operation: entering the next window rebuilds the display link and the willClose observer against that window, and pause state carries over via _displayLinkPaused.

Required for Fabric PR `<TBC>`