### PR TITLE
MetalViewController: make cleanup() public on macOS

### DIFF
--- a/Sources/Satin/Views/MetalViewController.swift
+++ b/Sources/Satin/Views/MetalViewController.swift
@@ -180,7 +180,7 @@ public final class MetalViewController: NSViewController {
         self.cleanup()
     }
 
-    func cleanup() {
+    public func cleanup() {
 #if DEBUG_VIEWS
         print("cleanup - MetalViewController: \(self.renderer.id)")
 #endif


### PR DESCRIPTION
One more for Feature – [Preview toggable between in-editor and separate window - #327](https://github.com/Fabric-Project/Fabric/pull/327).

> Hosts that re-parent the Metal view need deterministic renderer teardown when their document closes; cleanup() already existed for willTerminate but was internal, leaving deinit at ARC-determined release time as the only path. A renderer still marked set-up also makes any later controller created over it skip its own setup.

